### PR TITLE
chore(deps): bump path-to-regexp to 0.1.13 (fixes GHSA-37ch-88jc-xwx2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,65 +4,68 @@
   "description": "",
   "type": "module",
   "files": [
-    "dist"
+  "dist"
   ],
   "main": "./dist/no-mercy-player.umd.cjs",
   "module": "./dist/no-mercy-player.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/no-mercy-player.js",
-      "require": "./dist/no-mercy-player.umd.cjs"
-    }
+  ".": {
+    "import": "./dist/no-mercy-player.js",
+    "require": "./dist/no-mercy-player.umd.cjs"
+  }
   },
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
-    "serve": "vite preview",
-    "test": "jest",
-    "lint": "eslint ./src --ext .js,.ts,.d.ts --fix"
+  "dev": "vite",
+  "build": "tsc \u0026\u0026 vite build",
+  "serve": "vite preview",
+  "test": "jest",
+  "lint": "eslint ./src --ext .js,.ts,.d.ts --fix"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@tailwindcss/forms": "^0.5.3",
-    "@tailwindcss/line-clamp": "^0.4.4",
-    "@types/jest": "^29.5.5",
-    "@types/jwplayer": "^8.2.13",
-    "@types/node": "^18.14.2",
-    "@typescript-eslint/eslint-plugin": "^6.4.0",
-    "@typescript-eslint/parser": "^6.4.0",
-    "autoprefixer": "^10.4.14",
-    "copyfiles": "^2.4.1",
-    "css-loader": "^6.8.1",
-    "eslint": "^8.55.0",
-    "eslint-config-prettier": "^8.6.0",
-    "eslint-import-resolver-typescript": "^3.5.3",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-tailwindcss": "^3.8.3",
-    "jest": "^29.7.0",
-    "jwplayer": "^1.0.3",
-    "postcss": "^8.4.27",
-    "postcss-loader": "^7.3.3",
-    "postcss-preset-env": "^9.2.0",
-    "sass": "^1.65.1",
-    "sass-loader": "^13.3.2",
-    "style-loader": "^3.3.3",
-    "tailwindcss": "^3.2.7",
-    "ts-loader": "^9.4.4",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.6",
-    "video.js": "^8.0.4",
-    "videojs-playlist": "^5.0.0",
-    "vite": "^4.5.2",
-    "vite-plugin-dts": "^3.6.0",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1"
+  "@tailwindcss/forms": "^0.5.3",
+  "@tailwindcss/line-clamp": "^0.4.4",
+  "@types/jest": "^29.5.5",
+  "@types/jwplayer": "^8.2.13",
+  "@types/node": "^18.14.2",
+  "@typescript-eslint/eslint-plugin": "^6.4.0",
+  "@typescript-eslint/parser": "^6.4.0",
+  "autoprefixer": "^10.4.14",
+  "copyfiles": "^2.4.1",
+  "css-loader": "^6.8.1",
+  "eslint": "^8.55.0",
+  "eslint-config-prettier": "^8.6.0",
+  "eslint-import-resolver-typescript": "^3.5.3",
+  "eslint-plugin-import": "^2.27.5",
+  "eslint-plugin-prettier": "^4.2.1",
+  "eslint-plugin-tailwindcss": "^3.8.3",
+  "jest": "^29.7.0",
+  "jwplayer": "^1.0.3",
+  "postcss": "^8.4.27",
+  "postcss-loader": "^7.3.3",
+  "postcss-preset-env": "^9.2.0",
+  "sass": "^1.65.1",
+  "sass-loader": "^13.3.2",
+  "style-loader": "^3.3.3",
+  "tailwindcss": "^3.2.7",
+  "ts-loader": "^9.4.4",
+  "ts-node": "^10.9.1",
+  "typescript": "^5.1.6",
+  "video.js": "^8.0.4",
+  "videojs-playlist": "^5.0.0",
+  "vite": "^4.5.2",
+  "vite-plugin-dts": "^3.6.0",
+  "webpack": "^5.88.2",
+  "webpack-cli": "^5.1.4",
+  "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "tailwindcss-children": "^2.1.0"
+  "tailwindcss-children": "^2.1.0"
+  },
+  "overrides": {
+  "path-to-regexp": "^0.1.13"
   }
 }


### PR DESCRIPTION
Bumps `path-to-regexp` from `0.1.7` to `0.1.13` to address GHSA-37ch-88jc-xwx2.

path-to-regexp vulnerable to Regular Expression Denial of Service via multiple route parameters

Suggested by Shield. Severity: High.