### PR TITLE
chore(deps): bulk security fix — 18 packages, 55 advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "eslint-plugin-tailwindcss": "^3.8.3",
   "jest": "^29.7.0",
   "jwplayer": "^1.0.3",
-  "postcss": "^8.4.27",
+  "postcss": "^8.5.10",
   "postcss-loader": "^7.3.3",
   "postcss-preset-env": "^9.2.0",
   "sass": "^1.65.1",
@@ -58,7 +58,7 @@
   "videojs-playlist": "^5.0.0",
   "vite": "^4.5.2",
   "vite-plugin-dts": "^3.6.0",
-  "webpack": "^5.88.2",
+  "webpack": "^5.104.1",
   "webpack-cli": "^5.1.4",
   "webpack-dev-server": "^4.15.1"
   },
@@ -66,6 +66,21 @@
   "tailwindcss-children": "^2.1.0"
   },
   "overrides": {
-  "node-forge": "^1.4.0"
-  }
+  "node-forge": "^1.4.0",
+  "validator": "^13.15.22",
+  "picomatch": "^2.3.2",
+  "esbuild": "^0.25.0",
+  "lodash": "^4.18.0",
+  "micromatch": "^4.0.8",
+  "js-yaml": "^3.14.2",
+  "follow-redirects": "^1.16.0",
+  "ajv": "^6.14.0",
+  "nanoid": "^3.3.8",
+  "on-headers": "^1.1.0",
+  "send": "^0.19.0",
+  "qs": "^6.14.2",
+  "minimatch": "^3.1.4",
+  "cookie": "^0.7.0",
+  "min-document": "^2.19.1"
+}
 }


### PR DESCRIPTION
Automated bulk security fix by Shield.

**package.json**

- `validator` [`13.11.0` → [13.15.22](https://www.npmjs.com/package/validator/v/13.15.22)] — covers 3 advisories (GHSA-9965-vmph-33xx, GHSA-qgmg-gppg-76g5, GHSA-vghf-hv5q-vc2g)
- `webpack` [`5.89.0` → [5.104.1](https://www.npmjs.com/package/webpack/v/5.104.1)] — covers 4 advisories (GHSA-38r7-794h-5758, GHSA-4vvj-4cpr-p986, GHSA-8fgc-7cc6-rx7x, …and 1 more)
- `picomatch` [`2.3.1` → [2.3.2](https://www.npmjs.com/package/picomatch/v/2.3.2)] — covers 2 advisories (GHSA-3v7f-55p6-f55p, GHSA-c2c7-rcm5-vvqj)
- `esbuild` [`0.18.20` → [0.25.0](https://www.npmjs.com/package/esbuild/v/0.25.0)] — covers 1 advisory (GHSA-67mh-4wv8-2f99)
- `lodash` [`4.17.21` → [4.18.0](https://www.npmjs.com/package/lodash/v/4.18.0)] — covers 6 advisories (GHSA-29mw-wpgm-hmr9, GHSA-35jh-r3h4-6jhm, GHSA-f23m-r3pf-42rh, …and 3 more)
- `micromatch` [`4.0.5` → [4.0.8](https://www.npmjs.com/package/micromatch/v/4.0.8)] — covers 1 advisory (GHSA-952p-6rrq-rcjv)
- `js-yaml` [`3.14.1` → [3.14.2](https://www.npmjs.com/package/js-yaml/v/3.14.2)] — covers 1 advisory (GHSA-mh29-5h37-fv8m)
- `follow-redirects` [`1.15.5` → [1.16.0](https://www.npmjs.com/package/follow-redirects/v/1.16.0)] — covers 5 advisories (GHSA-74fj-2j2h-c42q, GHSA-cxjh-pqwp-8mfp, GHSA-jchw-25xp-jwwc, …and 2 more)
- `node-forge` [`1.3.1` → [1.4.0](https://www.npmjs.com/package/node-forge/v/1.4.0)] — covers 13 advisories (GHSA-2328-f5f3-gj25, GHSA-2r2c-g63r-vccr, GHSA-554w-wpv2-vw27, …and 10 more)
- `ajv` [`6.12.6` → [6.14.0](https://www.npmjs.com/package/ajv/v/6.14.0)] — covers 2 advisories (GHSA-2g4f-4pwh-qvx6, GHSA-v88g-cgmw-v5xw)
- `nanoid` [`3.3.7` → [3.3.8](https://www.npmjs.com/package/nanoid/v/3.3.8)] — covers 2 advisories (GHSA-mwcw-c2x4-8c55, GHSA-qrpm-p2h7-hrv2)
- `on-headers` [`1.0.2` → [1.1.0](https://www.npmjs.com/package/on-headers/v/1.1.0)] — covers 1 advisory (GHSA-76c9-3jph-rj3q)
- `postcss` [`8.4.32` → [8.5.10](https://www.npmjs.com/package/postcss/v/8.5.10)] — covers 4 advisories (GHSA-566m-qj78-rww5, GHSA-7fh5-64p2-3v2j, GHSA-hwj9-h5mp-3pm3, …and 1 more)
- `send` [`0.18.0` → [0.19.0](https://www.npmjs.com/package/send/v/0.19.0)] — covers 1 advisory (GHSA-m6fv-jmcg-4jfg)
- `qs` [`6.11.0` → [6.14.2](https://www.npmjs.com/package/qs/v/6.14.2)] — covers 3 advisories (GHSA-6rw7-vpxm-498p, GHSA-hrpp-h998-j3pp, GHSA-w7fw-mjwx-w883)
- `minimatch` [`3.1.2` → [3.1.4](https://www.npmjs.com/package/minimatch/v/3.1.4)] — covers 4 advisories (GHSA-23c5-xmqv-rm74, GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, …and 1 more)
- `cookie` [`0.5.0` → [0.7.0](https://www.npmjs.com/package/cookie/v/0.7.0)] — covers 1 advisory (GHSA-pxg6-pf52-xh8x)
- `min-document` [`2.19.0` → [2.19.1](https://www.npmjs.com/package/min-document/v/2.19.1)] — covers 1 advisory (GHSA-rx8g-88g5-qh64)

---
⚠️ **5 major-version bumps were skipped** (re-submit with `allowMajorBumps: true` to include):

- `vite` `4.5.2` → `7.3.2` (major)
- `tough-cookie` `2.5.0` → `4.1.3` (major)
- `serialize-javascript` `6.0.1` → `7.0.5` (major)
- `brace-expansion` `1.1.11` → `4.0.1` (major)
- `webpack-dev-server` `4.15.1` → `5.2.1` (major)

---
Suggested by [Shield](https://github.com/nomercylabs/shield). Review before merging.